### PR TITLE
Add flux-core@0.15.0 and flux-sched@0.8.0 to package and CI

### DIFF
--- a/.ci/run-build-tests.sh
+++ b/.ci/run-build-tests.sh
@@ -43,14 +43,29 @@ spack repo add $GITHUB_WORKSPACE
 # Print repos information
 spack repo list
 
+# Get the latest version (now that we've added the local repo)
+if [[ "$SPEC" == "latest-tag" ]]; then
+    CORE_SPEC=$(spack versions -s flux.flux-core | grep '[0-9.]' | head -n1)
+    SCHED_SPEC=$(spack versions -s flux.flux-sched | grep '[0-9.]' | head -n1)
+elif [[ "$SPEC" == "master" ]]; then
+    CORE_SPEC="$SPEC"
+    SCHED_SPEC="$SPEC"
+else
+    echo "Unrecognized SPEC: $SPEC"
+    exit 1
+fi
+
+# Print the SPEC
+echo "Spec: $SPEC"
+
 # Print compiler information
 spack config get compilers
 
 # Print spack spec
-spack spec -l flux-sched@${SPEC}
+spack spec -l flux-sched@${SCHED_SPEC}
 
 # Run some build smoke tests
-spack install --test=root --show-log-on-error flux.flux-core@${SPEC}
-spack load flux-core@${SPEC}
+spack install --test=root --show-log-on-error flux.flux-core@${CORE_SPEC}
+spack load flux-core@${CORE_SPEC}
 flux keygen # generate keys so that bootstrapping in flux-sched tests works
-spack install --test=root --show-log-on-error flux.flux-sched@${SPEC}
+spack install --test=root --show-log-on-error flux.flux-sched@${SCHED_SPEC}

--- a/.ci/run-build-tests.sh
+++ b/.ci/run-build-tests.sh
@@ -71,4 +71,4 @@ mount
 spack install --test=root --show-log-on-error flux.flux-core@${CORE_SPEC}
 spack load flux-core@${CORE_SPEC}
 flux keygen # generate keys so that bootstrapping in flux-sched tests works
-spack install --test=root --show-log-on-error flux.flux-sched@${SCHED_SPEC}
+spack install --test=root --show-log-on-error -j1 flux.flux-sched@${SCHED_SPEC}

--- a/.ci/run-build-tests.sh
+++ b/.ci/run-build-tests.sh
@@ -34,7 +34,7 @@ if [ -z "$SPEC" ]; then
     exit 1
 fi
 
-bin/spack bootstrap
+bin/spack -d bootstrap -v
 source $SPACK_ROOT/share/spack/setup-env.sh
 
 # Add this git repo as a spack repo
@@ -63,6 +63,9 @@ spack config get compilers
 
 # Print spack spec
 spack spec -l flux-sched@${SCHED_SPEC}
+
+# Print filesystem info (make sure flock'ing is supported)
+mount
 
 # Run some build smoke tests
 spack install --test=root --show-log-on-error flux.flux-core@${CORE_SPEC}

--- a/.github/workflows/build_tests_linux.yaml
+++ b/.github/workflows/build_tests_linux.yaml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         package:
           - master
+          - latest-tag
     steps:
     - uses: actions/checkout@v1
     - name: Cache ccache's store

--- a/packages/flux-core/package.py
+++ b/packages/flux-core/package.py
@@ -15,6 +15,7 @@ class FluxCore(AutotoolsPackage):
     git      = "https://github.com/flux-framework/flux-core.git"
 
     version('master', branch='master')
+    version('0.15.0', sha256='51bc2eae69501f802459fc82f191eb5e8ae0b4f7e9e77ac18543a850cc8445f5')
     version('0.11.3', sha256='91b5d7dca8fc28a77777c4e4cb8717fc3dc2c174e70611740689a71901c6de7e')
     version('0.11.2', sha256='ab8637428cd9b74b2dff4842d10e0fc4acc8213c4e51f31d32a4cbfbdf730412')
     version('0.11.1', sha256='3c8495db0f3b701f6dfe3e2a75aed794fc561e9f28284e8c02ac67693bfe890e')

--- a/packages/flux-sched/package.py
+++ b/packages/flux-sched/package.py
@@ -15,6 +15,7 @@ class FluxSched(AutotoolsPackage):
     git      = "https://github.com/flux-framework/flux-sched.git"
 
     version('master', branch='master')
+    version('0.8.0', sha256='45bc3cefb453d19c0cb289f03692fba600a39045846568d258e4b896ca19ca0d')
     version('0.7.1', sha256='a35e555a353feed6b7b814ae83d05362356f9ee33ffa75d7dfb7e2fe86c21294')
     version('0.7.0', sha256='69267a3aaacaedd9896fd90cfe17aef266cba4fb28c77f8123d95a31ce739a7b')
     version('0.6.0', sha256='3301d4c10810414228e5969b84b75fe1285abb97453070eb5a77f386d8184f8d')
@@ -41,6 +42,7 @@ class FluxSched(AutotoolsPackage):
     depends_on("flux-core@0.10.0", when='@0.6.0')
     depends_on("flux-core@0.11.0", when='@0.7.0')
     depends_on("flux-core@0.11.2:0.11.99", when='@0.7.1')
+    depends_on("flux-core@0.15.0:", when='@0.8.0')
     depends_on("flux-core@master", when='@master')
 
     # Need autotools when building on master:


### PR DESCRIPTION
Expands the Github Actions matrix to include the latest "safe version" (whatever that may be).