### PR TITLE
flux: overriding `check` is not necessary

### DIFF
--- a/.github/workflows/build_tests_linux.yaml
+++ b/.github/workflows/build_tests_linux.yaml
@@ -41,7 +41,7 @@ jobs:
         python-version: 3.8
     - name: Install System Packages
       run: |
-        sudo apt-get -yqq install git ccache openssl libssl-dev gfortran perl perl-base findutils
+        sudo apt-get -yqq install git ccache openssl libssl-dev gfortran perl perl-base findutils libc6-dbg
     - name: Clone spack
       run: |
         git clone https://github.com/spack/spack.git

--- a/packages/flux-core/package.py
+++ b/packages/flux-core/package.py
@@ -122,10 +122,6 @@ class FluxCore(AutotoolsPackage):
     def lua_lib_dir(self):
         return os.path.join('lib', 'lua', str(self.lua_version))
 
-    def check(self):
-        with working_dir(self.build_directory):
-            self.make('check')
-
     def setup_build_environment(self, env):
         #  Ensure ./fluxometer.lua can be found during flux's make check
         env.append_path('LUA_PATH', './?.lua', separator=';')

--- a/packages/flux-sched/package.py
+++ b/packages/flux-sched/package.py
@@ -108,10 +108,6 @@ class FluxSched(AutotoolsPackage):
     def lua_lib_dir(self):
         return os.path.join('lib', 'lua', str(self.lua_version))
 
-    def check(self):
-        with working_dir(self.build_directory):
-            self.make('check')
-
     def setup_run_environment(self, env):
         env.prepend_path(
             'LUA_PATH',


### PR DESCRIPTION
spack should correctly determine that `test` is not a valid target and
that `check` is sufficient.  reduce complexity of our spack package by
removing unnecessary overrides