### PR TITLE
ci: disable `spack bootstrap` and sourcing of `setup-env.sh`

### DIFF
--- a/.ci/run-build-tests.sh
+++ b/.ci/run-build-tests.sh
@@ -54,6 +54,8 @@ else
     echo "Unrecognized SPEC: $SPEC"
     exit 1
 fi
+CORE_SPEC=${CORE_SPEC}"^flux.lua@5.2.4"
+SCHED_SPEC=${SCHED_SPEC}"^flux.lua@5.2.4"
 
 # Print the SPEC
 echo "Spec: $SPEC"

--- a/.ci/run-build-tests.sh
+++ b/.ci/run-build-tests.sh
@@ -64,7 +64,7 @@ echo "Spec: $SPEC"
 bin/spack config get compilers
 
 # Print spack spec
-bin/spack spec -l flux-sched@${SCHED_SPEC}
+bin/spack spec -Nl flux.flux-sched@${SCHED_SPEC}
 
 # Print filesystem info (make sure flock'ing is supported)
 mount

--- a/.ci/run-build-tests.sh
+++ b/.ci/run-build-tests.sh
@@ -34,14 +34,14 @@ if [ -z "$SPEC" ]; then
     exit 1
 fi
 
-bin/spack -d bootstrap -v
-source $SPACK_ROOT/share/spack/setup-env.sh
+#bin/spack -d bootstrap -v
+#source $SPACK_ROOT/share/spack/setup-env.sh
 
 # Add this git repo as a spack repo
-spack repo add $GITHUB_WORKSPACE
+bin/spack repo add $GITHUB_WORKSPACE
 
 # Print repos information
-spack repo list
+bin/spack repo list
 
 # Get the latest version (now that we've added the local repo)
 if [[ "$SPEC" == "latest-tag" ]]; then
@@ -59,10 +59,10 @@ fi
 echo "Spec: $SPEC"
 
 # Print compiler information
-spack config get compilers
+bin/spack config get compilers
 
 # Print spack spec
-spack spec -l flux-sched@${SCHED_SPEC}
+bin/spack spec -l flux-sched@${SCHED_SPEC}
 
 # Print filesystem info (make sure flock'ing is supported)
 mount
@@ -71,7 +71,7 @@ mount
 export FLUX_TESTS_LOGFILE=t
 
 # Run some build smoke tests
-spack install --test=root --show-log-on-error flux.flux-core@${CORE_SPEC}
-spack load flux-core@${CORE_SPEC}
-flux keygen # generate keys so that bootstrapping in flux-sched tests works
-spack install --test=root --show-log-on-error -j1 flux.flux-sched@${SCHED_SPEC}
+bin/spack install --test=root --show-log-on-error flux.flux-core@${CORE_SPEC}
+# generate keys so that bootstrapping in flux-sched tests works
+$(bin/spack location -i flux-core@${CORE_SPEC})/bin/flux keygen
+bin/spack install --test=root --show-log-on-error -j1 flux.flux-sched@${SCHED_SPEC}

--- a/.github/workflows/build_tests_linux.yaml
+++ b/.github/workflows/build_tests_linux.yaml
@@ -20,7 +20,7 @@ jobs:
           - master
           - latest-tag
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: always-upload-cache
       uses: pat-s/always-upload-cache@v1.1.4
       with:

--- a/.github/workflows/build_tests_linux.yaml
+++ b/.github/workflows/build_tests_linux.yaml
@@ -21,13 +21,22 @@ jobs:
           - latest-tag
     steps:
     - uses: actions/checkout@v1
-    - name: Cache ccache's store
-      uses: actions/cache@v1
+    - name: always-upload-cache
+      uses: pat-s/always-upload-cache@v1.1.4
       with:
         path: ~/.ccache
         key: ccache-build-${{ matrix.package }}
         restore-keys: |
           ccache-build-${{ matrix.package }}
+          ccache-build-master
+          ccache-build-latest-tag
+    # - name: Cache ccache's store
+    #   uses: actions/cache@v1
+    #   with:
+    #     path: ~/.ccache
+    #     key: ccache-build-${{ matrix.package }}
+    #     restore-keys: |
+    #       ccache-build-${{ matrix.package }}
     # - name: Cache spack's local mirror
     #   uses: actions/cache@v1
     #   with:
@@ -49,7 +58,7 @@ jobs:
       run: |
         # Set up external deps for build tests, b/c they take too long to compile
         cp .ci/*.yaml spack/etc/spack/
-        ccache -M 500M && ccache -z
+        ccache -M 2.4G && ccache -z
     - name: Run the build test
       run: |
         . spack/share/spack/setup-env.sh

--- a/packages/flux-core/package.py
+++ b/packages/flux-core/package.py
@@ -15,6 +15,7 @@ class FluxCore(AutotoolsPackage):
     git      = "https://github.com/flux-framework/flux-core.git"
 
     version('master', branch='master')
+    version('0.16.0', sha256='1582f7fb4d2313127418c34de7c9ce4f5fef00622d19cedca7bed929f4709f10')
     version('0.15.0', sha256='51bc2eae69501f802459fc82f191eb5e8ae0b4f7e9e77ac18543a850cc8445f5')
     version('0.11.3', sha256='91b5d7dca8fc28a77777c4e4cb8717fc3dc2c174e70611740689a71901c6de7e')
     version('0.11.2', sha256='ab8637428cd9b74b2dff4842d10e0fc4acc8213c4e51f31d32a4cbfbdf730412')

--- a/packages/flux-sched/package.py
+++ b/packages/flux-sched/package.py
@@ -34,6 +34,7 @@ class FluxSched(AutotoolsPackage):
     depends_on("yaml-cpp", when="@0.7.0:")
     depends_on("libuuid")
     depends_on("pkgconfig")
+    depends_on("readline")
 
     depends_on("flux-core", type=('build', 'link', 'run'))
     depends_on("flux-core+cuda", when='+cuda')

--- a/packages/lua/package.py
+++ b/packages/lua/package.py
@@ -1,0 +1,183 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+import os
+
+
+class Lua(Package):
+    """The Lua programming language interpreter and library."""
+
+    homepage = "http://www.lua.org"
+    url = "http://www.lua.org/ftp/lua-5.3.4.tar.gz"
+
+    version('5.3.5', sha256='0c2eed3f960446e1a3e4b9a1ca2f3ff893b6ce41942cf54d5dd59ab4b3b058ac')
+    version('5.3.4', sha256='f681aa518233bc407e23acf0f5887c884f17436f000d453b2491a9f11a52400c')
+    version('5.3.2', sha256='c740c7bb23a936944e1cc63b7c3c5351a8976d7867c5252c8854f7b2af9da68f')
+    version('5.3.1', sha256='072767aad6cc2e62044a66e8562f51770d941e972dc1e4068ba719cd8bffac17')
+    version('5.3.0', sha256='ae4a5eb2d660515eb191bfe3e061f2b8ffe94dce73d32cfd0de090ddcc0ddb01')
+    version('5.2.4', sha256='b9e2e4aad6789b3b63a056d442f7b39f0ecfca3ae0f1fc0ae4e9614401b69f4b')
+    version('5.2.3', sha256='13c2fb97961381f7d06d5b5cea55b743c163800896fd5c5e2356201d3619002d')
+    version('5.2.2', sha256='3fd67de3f5ed133bf312906082fa524545c6b9e1b952e8215ffbd27113f49f00')
+    version('5.2.1', sha256='64304da87976133196f9e4c15250b70f444467b6ed80d7cfd7b3b982b5177be5')
+    version('5.2.0', sha256='cabe379465aa8e388988073d59b69e76ba0025429d2c1da80821a252cdf6be0d')
+    version('5.1.5', sha256='2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333')
+    version('5.1.4', sha256='b038e225eaf2a5b57c9bcc35cd13aa8c6c8288ef493d52970c9545074098af3a')
+    version('5.1.3', sha256='6b5df2edaa5e02bf1a2d85e1442b2e329493b30b0c0780f77199d24f087d296d')
+
+    extendable = True
+
+    depends_on('ncurses')
+    depends_on('readline')
+    # luarocks needs unzip for some packages (e.g. lua-luaposix)
+    depends_on('unzip', type='run')
+
+    resource(
+        name="luarocks",
+        url="https://keplerproject.github.io/luarocks/releases/"
+        "luarocks-2.3.0.tar.gz",
+        sha256="68e38feeb66052e29ad1935a71b875194ed8b9c67c2223af5f4d4e3e2464ed97",
+        destination="luarocks",
+        placement='luarocks')
+
+    def install(self, spec, prefix):
+        if spec.satisfies("platform=darwin"):
+            target = 'macosx'
+        else:
+            target = 'linux'
+        make('INSTALL_TOP=%s' % prefix,
+             'MYLDFLAGS=-L%s -L%s' % (
+                 spec['readline'].prefix.lib,
+                 spec['ncurses'].prefix.lib),
+             'MYLIBS=-lncursesw -ltermcap',
+             'CC=%s -std=gnu99 %s' % (spack_cc,
+                                      self.compiler.pic_flag),
+             target)
+        make('INSTALL_TOP=%s' % prefix,
+             'install')
+
+        static_to_shared_library(join_path(prefix.lib, 'liblua.a'),
+                                 arguments=['-lm', '-ldl'],
+                                 version=self.version,
+                                 compat_version=self.version.up_to(2))
+
+        # compatibility with ax_lua.m4 from autoconf-archive
+        # https://www.gnu.org/software/autoconf-archive/ax_lua.html
+        with working_dir(prefix.lib):
+            # e.g., liblua.so.5.1.5
+            src_path = 'liblua.{0}.{1}'.format(dso_suffix,
+                                               str(self.version.up_to(3)))
+
+            # For lua version 5.1.X, the symlinks should be:
+            # liblua5.1.so
+            # liblua51.so
+            # liblua-5.1.so
+            # liblua-51.so
+            version_formats = [str(self.version.up_to(2)),
+                               Version(str(self.version.up_to(2))).joined]
+            for version_str in version_formats:
+                for joiner in ['', '-']:
+                    dest_path = 'liblua{0}{1}.{2}'.format(joiner,
+                                                          version_str,
+                                                          dso_suffix)
+                    os.symlink(src_path, dest_path)
+
+        with working_dir(os.path.join('luarocks', 'luarocks')):
+            configure('--prefix=' + prefix, '--with-lua=' + prefix)
+            make('build')
+            make('install')
+
+    def append_paths(self, paths, cpaths, path):
+        paths.append(os.path.join(path, '?.lua'))
+        paths.append(os.path.join(path, '?', 'init.lua'))
+        cpaths.append(os.path.join(path, '?.so'))
+
+    def _setup_dependent_env_helper(self, env, dependent_spec):
+        lua_paths = []
+        for d in dependent_spec.traverse(
+                deptypes=('build', 'run'), deptype_query='run'):
+            if d.package.extends(self.spec):
+                lua_paths.append(os.path.join(d.prefix, self.lua_lib_dir))
+                lua_paths.append(os.path.join(d.prefix, self.lua_lib64_dir))
+                lua_paths.append(os.path.join(d.prefix, self.lua_share_dir))
+
+        lua_patterns = []
+        lua_cpatterns = []
+        for p in lua_paths:
+            if os.path.isdir(p):
+                self.append_paths(lua_patterns, lua_cpatterns, p)
+
+        # Always add this package's paths
+        for p in (os.path.join(self.spec.prefix, self.lua_lib_dir),
+                  os.path.join(self.spec.prefix, self.lua_lib64_dir),
+                  os.path.join(self.spec.prefix, self.lua_share_dir)):
+            self.append_paths(lua_patterns, lua_cpatterns, p)
+
+        return lua_patterns, lua_cpatterns
+
+    def setup_dependent_build_environment(self, env, dependent_spec):
+        lua_patterns, lua_cpatterns = self._setup_dependent_env_helper(
+            env, dependent_spec)
+
+        env.set('LUA_PATH', ';'.join(lua_patterns), separator=';')
+        env.set('LUA_CPATH', ';'.join(lua_cpatterns), separator=';')
+
+    def setup_dependent_run_environment(self, env, dependent_spec):
+        # For run time environment set only the path for dependent_spec and
+        # prepend it to LUAPATH
+        lua_patterns, lua_cpatterns = self._setup_dependent_env_helper(
+            env, dependent_spec)
+
+        if dependent_spec.package.extends(self.spec):
+            env.prepend_path('LUA_PATH', ';'.join(lua_patterns), separator=';')
+            env.prepend_path('LUA_CPATH', ';'.join(lua_cpatterns),
+                             separator=';')
+
+    def setup_run_environment(self, env):
+        env.prepend_path(
+            'LUA_PATH',
+            os.path.join(self.spec.prefix, self.lua_share_dir, '?.lua'),
+            separator=';')
+        env.prepend_path(
+            'LUA_PATH', os.path.join(self.spec.prefix, self.lua_share_dir, '?',
+                                     'init.lua'),
+            separator=';')
+        env.prepend_path(
+            'LUA_PATH',
+            os.path.join(self.spec.prefix, self.lua_lib_dir, '?.lua'),
+            separator=';')
+        env.prepend_path(
+            'LUA_PATH',
+            os.path.join(self.spec.prefix, self.lua_lib_dir, '?', 'init.lua'),
+            separator=';')
+        env.prepend_path(
+            'LUA_CPATH',
+            os.path.join(self.spec.prefix, self.lua_lib_dir, '?.so'),
+            separator=';')
+
+    @property
+    def lua_lib_dir(self):
+        return os.path.join('lib', 'lua', str(self.version.up_to(2)))
+
+    @property
+    def lua_lib64_dir(self):
+        return os.path.join('lib64', 'lua', str(self.version.up_to(2)))
+
+    @property
+    def lua_share_dir(self):
+        return os.path.join('share', 'lua', str(self.version.up_to(2)))
+
+    def setup_dependent_package(self, module, dependent_spec):
+        """
+        Called before lua modules's install() methods.
+
+        In most cases, extensions will only need to have two lines::
+
+        luarocks('--tree=' + prefix, 'install', rock_spec_path)
+        """
+        # Lua extension builds can have lua and luarocks executable functions
+        module.lua = Executable(join_path(self.spec.prefix.bin, 'lua'))
+        module.luarocks = Executable(
+            join_path(self.spec.prefix.bin, 'luarocks'))


### PR DESCRIPTION
Problem: the github workflow occassionally hangs on bootstrap.  

Solution: Remove that (ultimately unnecssary) step to minimize debugging efforts down the road.