### PR TITLE
testing if github token scope is enough to see release details

### DIFF
--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -1,0 +1,30 @@
+name: Update with latest flux release
+on:
+  pull_request: []
+  schedule:
+    - cron:  '0 10 * * *'
+
+jobs:
+  get-release-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch release version
+        run: |
+          curl -sL https://api.github.com/repos/flux-framework/flux-core/releases/latest
+          curl -sL https://api.github.com/repos/flux-framework/flux-core/releases/latest | \
+          jq -r ".tag_name" > FLUX_CORE_VERSION
+      - name: Check for modified files
+        id: git-check
+        run: echo ::set-output name=modified::$([ -z "`git status --porcelain`" ] && echo "false" || echo "true")
+      - name: Commit latest release version
+        if: steps.git-check.outputs.modified == 'true'
+        run: |
+          echo "There are modified files"
+          cat FLUX_CORE_VERSION
+#          git config --global user.name 'github-actions'
+#          git config --global user.email 'github-actions@users.noreply.github.com'
+#          git commit -am "New release version"
+#          git push


### PR DESCRIPTION
This is just a test.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>